### PR TITLE
Setup unit testing using Unity with CMake and Pixi integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "external/unity/external/unity"]
-	path = external/unity/external/unity
+[submodule "external/unity"]
+	path = external/unity
 	url = https://github.com/ThrowTheSwitch/Unity.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/unity/external/unity"]
+	path = external/unity/external/unity
+	url = https://github.com/ThrowTheSwitch/Unity.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(rocky)
 
+enable_testing()
+
 if(WIN32)
   set(CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}/Library")
   set(LLVM_USE_SHARED_LIBS ON)
@@ -15,9 +17,11 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(external/unity/src)
 add_definitions(${LLVM_DEFINITIONS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
+#main app
 add_executable(rocky src/main.c)
 target_include_directories(rocky PUBLIC include)
 if(WIN32)
@@ -26,3 +30,33 @@ else()
   llvm_map_components_to_libnames(llvm_libs core support native target mc asmprinter orcjit executionengine)
   target_link_libraries(rocky ${llvm_libs})
 endif()
+
+#testing setup
+add_executable(test_main
+    tests/core/test_main.c
+    external/unity/src/unity.c
+)
+target_include_directories(test_main PUBLIC include external/unity/src)
+if(WIN32)
+  target_link_libraries(test_main LLVM-C)
+else()
+  target_link_libraries(test_main ${llvm_libs})
+endif()
+add_test(NAME test_main COMMAND test_main)
+
+#testing of math
+add_executable(test_math
+    tests/core/test_math.c
+    src/math.c
+    external/unity/src/unity.c
+)
+
+target_include_directories(test_math PUBLIC include external/unity/src)
+
+if(WIN32)
+  target_link_libraries(test_math LLVM-C)
+else()
+  target_link_libraries(test_math ${llvm_libs})
+endif()
+
+add_test(NAME test_math COMMAND test_math)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ foreach(test_src ${TEST_SOURCES})
     file(RELATIVE_PATH rel_dir ${CMAKE_SOURCE_DIR} ${test_dir})
 
     string(REPLACE "/" "_" rel_dir_name ${rel_dir})
-
     set(test_name "${rel_dir_name}_${test_file}")
 
     add_executable(${test_name}
@@ -77,5 +76,13 @@ foreach(test_src ${TEST_SOURCES})
     )
 
     add_test(NAME ${test_name} COMMAND ${test_name})
+
+    string(REPLACE "tests/" "" rel_dir_clean ${rel_dir})
+
+    set(test_label "${rel_dir_clean}/${test_file}")
+
+    set_tests_properties(${test_name} PROPERTIES
+        LABELS ${test_label}
+    )
 
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,32 +31,51 @@ else()
   target_link_libraries(rocky ${llvm_libs})
 endif()
 
-#testing setup
-add_executable(test_main
-    tests/core/test_main.c
-    external/unity/src/unity.c
-)
-target_include_directories(test_main PUBLIC include external/unity/src)
-if(WIN32)
-  target_link_libraries(test_main LLVM-C)
-else()
-  target_link_libraries(test_main ${llvm_libs})
-endif()
-add_test(NAME test_main COMMAND test_main)
 
-#testing of math
-add_executable(test_math
-    tests/core/test_math.c
-    src/math.c
-    external/unity/src/unity.c
+#Testing Part
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
+    ${CMAKE_SOURCE_DIR}/src/*.c
 )
 
-target_include_directories(test_math PUBLIC include external/unity/src)
+list(REMOVE_ITEM SRC_FILES ${CMAKE_SOURCE_DIR}/src/main.c)
 
-if(WIN32)
-  target_link_libraries(test_math LLVM-C)
-else()
-  target_link_libraries(test_math ${llvm_libs})
-endif()
+file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_SOURCE_DIR}/tests/**/*.c
+)
 
-add_test(NAME test_math COMMAND test_math)
+foreach(test_src ${TEST_SOURCES})
+    get_filename_component(test_file ${test_src} NAME_WE)
+
+    get_filename_component(test_dir ${test_src} DIRECTORY)
+    file(RELATIVE_PATH rel_dir ${CMAKE_SOURCE_DIR} ${test_dir})
+
+    string(REPLACE "/" "_" rel_dir_name ${rel_dir})
+
+    set(test_name "${rel_dir_name}_${test_file}")
+
+    add_executable(${test_name}
+        ${test_src}
+        ${SRC_FILES}
+        external/unity/src/unity.c
+    )
+
+    target_include_directories(${test_name} PUBLIC
+        include
+        external/unity/src
+    )
+
+    if(WIN32)
+        target_link_libraries(${test_name} LLVM-C)
+    else()
+        target_link_libraries(${test_name} ${llvm_libs})
+    endif()
+
+    set_target_properties(${test_name} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${rel_dir}
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/${rel_dir}
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/${rel_dir}
+    )
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
+
+endforeach()

--- a/include/rocky/math.h
+++ b/include/rocky/math.h
@@ -1,0 +1,6 @@
+#ifndef MATH_H
+#define MATH_H
+
+int add(int a, int b);
+
+#endif

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,9 +11,7 @@ configure = "cmake -S . -B build -G \"Ninja\" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 run = { cmd = "./build/rocky", depends-on = ["compile"] }
 clean = "rm -r build"
 compile = { cmd = "cmake --build build", depends-on = ["configure"] }
-test = { cmd = "ctest --test-dir build", depends-on = ["compile"] }
-test-one = { cmd = "ctest --test-dir build -R {{ test_name }}", depends-on = ["compile"], args = ["test_name"] }
-test-group = { cmd = "ctest --test-dir build -R {{ group_name }}", depends-on = ["compile"], args = ["group_name"] }
+test = { cmd = "ctest --test-dir build -L {{ label }}", depends-on = ["compile"], args = [{ arg = "label", default = ".+" }] }
 
 # Windows auto-installs and uses msvc
 [target.win-64.tasks]
@@ -24,9 +22,7 @@ configure = { cmd = "cmd /C msvcup-autoenv install && cmake -S . -B build -G \"N
 run       = { cmd = "cmd /C .\\build\\rocky.exe", depends-on = ["compile"] }
 clean = "cmd /C rmdir /S /Q %PIXI_PROJECT_ROOT%\\build"
 compile = { cmd = "cmd /C cmake --build build", depends-on = ["configure"] }
-test = { cmd = "cmd /C ctest --test-dir build", depends-on = ["compile"] }
-test-one = { cmd = "cmd /C ctest --test-dir build -R {{ test_name }}", depends-on = ["compile"], args = ["test_name"] }
-test-group = { cmd = "cmd /C ctest --test-dir build -R {{ group_name }}", depends-on = ["compile"], args = ["group_name"] }
+test = { cmd = "cmd /C ctest --test-dir build -L {{ label }}", depends-on = ["compile"], args = [{ arg = "label", default = ".+" }] }
 
 [dependencies]
 cmake = ">=4.3.1,<5"

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,8 @@ run = { cmd = "./build/rocky", depends-on = ["compile"] }
 clean = "rm -r build"
 compile = { cmd = "cmake --build build", depends-on = ["configure"] }
 test = { cmd = "ctest --test-dir build", depends-on = ["compile"] }
+test-one = { cmd = "ctest --test-dir build -R {{ test_name }}", depends-on = ["compile"], args = ["test_name"] }
+test-group = { cmd = "ctest --test-dir build -R {{ group_name }}", depends-on = ["compile"], args = ["group_name"] }
 
 # Windows auto-installs and uses msvc
 [target.win-64.tasks]
@@ -23,6 +25,8 @@ run       = { cmd = "cmd /C .\\build\\rocky.exe", depends-on = ["compile"] }
 clean = "cmd /C rmdir /S /Q %PIXI_PROJECT_ROOT%\\build"
 compile = { cmd = "cmd /C cmake --build build", depends-on = ["configure"] }
 test = { cmd = "cmd /C ctest --test-dir build", depends-on = ["compile"] }
+test-one = { cmd = "cmd /C ctest --test-dir build -R {{ test_name }}", depends-on = ["compile"], args = ["test_name"] }
+test-group = { cmd = "cmd /C ctest --test-dir build -R {{ group_name }}", depends-on = ["compile"], args = ["group_name"] }
 
 [dependencies]
 cmake = ">=4.3.1,<5"

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,7 @@ configure = "cmake -S . -B build -G \"Ninja\" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 run = { cmd = "./build/rocky", depends-on = ["compile"] }
 clean = "rm -r build"
 compile = { cmd = "cmake --build build", depends-on = ["configure"] }
+test = { cmd = "ctest --test-dir build", depends-on = ["compile"] }
 
 # Windows auto-installs and uses msvc
 [target.win-64.tasks]
@@ -21,6 +22,7 @@ configure = { cmd = "cmd /C msvcup-autoenv install && cmake -S . -B build -G \"N
 run       = { cmd = "cmd /C .\\build\\rocky.exe", depends-on = ["compile"] }
 clean = "cmd /C rmdir /S /Q %PIXI_PROJECT_ROOT%\\build"
 compile = { cmd = "cmd /C cmake --build build", depends-on = ["configure"] }
+test = { cmd = "cmd /C ctest --test-dir build", depends-on = ["compile"] }
 
 [dependencies]
 cmake = ">=4.3.1,<5"

--- a/src/math.c
+++ b/src/math.c
@@ -1,0 +1,5 @@
+#include <rocky/math.h>
+
+int add(int a, int b) {
+    return a + b;
+}

--- a/tests/core/test_main.c
+++ b/tests/core/test_main.c
@@ -1,0 +1,16 @@
+#include "unity.h"
+#include <rocky/main.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_hello_world_runs(void) {
+    hello_world();
+    TEST_ASSERT_TRUE(1);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_hello_world_runs);
+    return UNITY_END();
+}

--- a/tests/core/test_math.c
+++ b/tests/core/test_math.c
@@ -1,0 +1,26 @@
+#include "unity.h"
+#include <rocky/math.h>
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_add_pass(void){
+    TEST_ASSERT_EQUAL(5, add(2, 3));
+}
+
+void test_add_fail(void){
+    TEST_ASSERT_NOT_EQUAL(6, add(2, 3));
+}
+
+void test_add_negative(void) {
+    TEST_ASSERT_EQUAL(-1, add(2, -3));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_add_pass);
+    RUN_TEST(test_add_fail);
+    RUN_TEST(test_add_negative);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

This PR sets up unit testing for the project using the Unity framework and integrates it with the existing CMake and Pixi workflow. Closes #7

## Changes

* Added Unity as a submodule under `external/unity`
* Integrated unit testing with CMake using `enable_testing()` and `add_test()`
* Created a structured test directory under `tests/` with component-based organization
* Added sample unit tests:

  * `test_main.c` for basic setup validation
  * `test_math.c` demonstrating a stub component (`add` function)
* Added Pixi task `pixi run test` to build and run all tests

## Test Structure

```
tests/
  core/
    test_main.c
    test_math.c
  lexer/
  parser/
```

## How to Run Tests

```
pixi run test
```

## Notes

* A simple `math` module was added to demonstrate how components map to their respective unit tests
* Test cases include passing, failing-style, and edge-case scenarios to showcase Unity features
* Structure is prepared for future components like lexer and parser
