### PR TITLE
fix: naming conventions and Windows ANSI color support

### DIFF
--- a/include/rocky/debug/debug.h
+++ b/include/rocky/debug/debug.h
@@ -7,31 +7,31 @@
 
 /* Bitmask enum for conditional printing of tokens */ 
 typedef enum {
-    KIND = 1 << 0,
-    LEXEME = 1 << 1,
-    LINE = 1 << 2,
-    COL = 1 << 3,
-} TokenFlags;
+    TOK_PRINT_FLAG_KIND = 1 << 0,
+    TOK_PRINT_FLAG_LEXEME = 1 << 1,
+    TOK_PRINT_FLAG_LINE = 1 << 2,
+    TOK_PRINT_FLAG_COL = 1 << 3,
+} TokenPrintFlags;
 
 /* Convert TokenType enum to a human-readable string. */
-const char* tokenTypeStr(TokenType type);
+const char* token_type_str(TokenType type);
 
 /* Convert UnaryOp enum to a human-readable string. */
-const char* unaryOpStr(UnaryOp op);
+const char* unary_op_str(UnaryOp op);
 
 /* Convert TypeKind enum to a human-readable string. */
-const char* typeStr(TypeKind t);
+const char* datatype_str(TypeKind t);
 
 /* Convert BinaryOP enum to a human-readable string. */
-const char* binaryOpStr(BinaryOp op);
+const char* binary_op_str(BinaryOp op);
 
 /* Diagnostic printer for lexer
  * Params: 
  * 1.token: pointer to the token struct.
  * 2.flags: bitmask specifying which fields to print (KIND, LEXEME, LINE, COL).
- * Sample usage: printToken(token, KIND | LINE) will print the token type and its line number.
+ * * Sample usage: print_token(token, TOK_PRINT_FLAG_KIND | TOK_PRINT_FLAG_LINE) will print the token type and its line.
  * */
-void printToken(Token* token, unsigned int flags);
+void print_token(Token* token, TokenPrintFlags flags);
 
 /* Diagnostic printer for AST nodes
  * Params: 
@@ -41,6 +41,5 @@ void printToken(Token* token, unsigned int flags);
  * 4. sibling: bitmask tracking which ancestor levels were the last child, used for drawing tree branches correctly.
  * Sample Usage: printExpr(expr, 0, 1, 0);
  * */
-void printExpr(const Expr* expr, int depth, int isLast, int sibling);
-void printAll(void);
+void print_expr(const Expr* expr, int depth, int isLast, int sibling);
 #endif

--- a/include/rocky/debug/debug.h
+++ b/include/rocky/debug/debug.h
@@ -11,6 +11,7 @@ typedef enum {
     TOK_PRINT_FLAG_LEXEME = 1 << 1,
     TOK_PRINT_FLAG_LINE = 1 << 2,
     TOK_PRINT_FLAG_COL = 1 << 3,
+    TOK_PRINT_ALL = 0xF,
 } TokenPrintFlags;
 
 /* Convert TokenType enum to a human-readable string. */

--- a/src/debug/debug.c
+++ b/src/debug/debug.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 
 #ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     static int use_color(void) {
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/src/debug/debug.c
+++ b/src/debug/debug.c
@@ -1,13 +1,25 @@
 #include<rocky/debug/debug.h>
 #include<stdio.h>
 #include <inttypes.h>
-#include <unistd.h>
 
-static int use_color(void) {
-    return isatty(fileno(stdout));
-}
+#ifdef _WIN32
+    #include <windows.h>
+    static int use_color(void) {
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hOut == INVALID_HANDLE_VALUE) return 0;
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(hOut, &dwMode)) return 0;
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        return SetConsoleMode(hOut, dwMode);
+    }
+#else
+    #include <unistd.h>
+    static int use_color(void) {
+        return isatty(fileno(stdout));
+    }
+#endif
 
-const char* tokenTypeStr(TokenType type) {
+const char* token_type_str(TokenType type) {
     switch (type) {
         /*  Literals  */
         case TOKEN_INT: return "INT";
@@ -35,7 +47,7 @@ const char* tokenTypeStr(TokenType type) {
     }
 }
 
-void printToken(Token* token, unsigned int flags) {
+void print_token(Token* token, TokenPrintFlags flags) {
     //Null guard
     if (!token) {
         printf("[NULL TOKEN]\n");
@@ -50,11 +62,11 @@ void printToken(Token* token, unsigned int flags) {
     const char *red    = color ? "\e[35m" : "";
     const char *reset  = color ? "\e[0m"  : "";
 
-    if (flags & KIND)
+    if (flags & TOK_PRINT_FLAG_KIND)
         printf("%s%-15s%s   ",
-               cyan, tokenTypeStr(token->type), reset);
+               cyan, token_type_str(token->type), reset);
 
-    if (flags & LEXEME) {
+    if (flags & TOK_PRINT_FLAG_LEXEME) {
         if (token->start) {
             printf("%s%-15.*s%s   ",
                    green, (int)token->length, token->start, reset);
@@ -64,18 +76,18 @@ void printToken(Token* token, unsigned int flags) {
         }
     }
 
-    if (flags & LINE)
+    if (flags & TOK_PRINT_FLAG_LINE)
         printf("%s%-5d%s   ",
                yellow, token->line, reset);
 
-    if (flags & COL)
+    if (flags & TOK_PRINT_FLAG_COL)
         printf("%s%-5d%s   ",
                red, token->column, reset);
 
     printf("\n");
 }
 
-const char* unaryOpStr(UnaryOp op) {
+const char* unary_op_str(UnaryOp op) {
     switch (op) {
         case UNOP_NEG: return "-";
         case UNOP_BITNOT: return "~";
@@ -84,7 +96,7 @@ const char* unaryOpStr(UnaryOp op) {
     }
 }
 
-const char* typeStr(TypeKind t) {
+const char* datatype_str(TypeKind t) {
     switch (t) {
         case TYPE_INT: return "int";
         case TYPE_FLOAT: return "float";
@@ -94,7 +106,7 @@ const char* typeStr(TypeKind t) {
     }
 }
 
-const char* binaryOpStr(BinaryOp op) {
+const char* binary_op_str(BinaryOp op) {
     switch (op) {
 
         /* arithmetic */
@@ -143,11 +155,11 @@ const char* binaryOpStr(BinaryOp op) {
  *  - depth: current depth in the AST
  *  - sibling: bitmask tracking which ancestor levels were last children
  */
-void printChildren(const Expr** children, int count, int depth, int sibling) {
+void print_children(const Expr** children, int count, int depth, int sibling) {
     for (int i = 0; i < count; i++) {
         int isLast = (i == count - 1);
         int newMask = sibling | (isLast << depth);
-        printExpr(children[i], depth + 1, isLast, newMask);
+        print_expr(children[i], depth + 1, isLast, newMask);
     }
 }
 
@@ -160,7 +172,7 @@ void printChildren(const Expr** children, int count, int depth, int sibling) {
  * If a bit is set, we print spaces instead of vertical lines (│),
  * ensuring correct tree visualization across multiple branches.
  */
-void printExpr(const Expr* expr, int depth, int isLast, int sibling) {  
+void print_expr(const Expr* expr, int depth, int isLast, int sibling) {  
     //Null guard
     if (!expr) {
         printf("[NULL EXPR]\n");
@@ -205,18 +217,18 @@ void printExpr(const Expr* expr, int depth, int isLast, int sibling) {
             break;
                 
         case EXPR_UNARY:
-            printf("%s\n", unaryOpStr(expr->as.unary.op));
-            printExpr(expr->as.unary.operand, depth + 1, 1, sibling | (1 << depth));
+            printf("%s\n", unary_op_str(expr->as.unary.op));
+            print_expr(expr->as.unary.operand, depth + 1, 1, sibling | (1 << depth));
             break;
         case EXPR_BINARY:
-            printf("%s\n", binaryOpStr(expr->as.binary.op));
+            printf("%s\n", binary_op_str(expr->as.binary.op));
             const Expr* children[] = {expr->as.binary.lhs, expr->as.binary.rhs};
-            printChildren(children, 2, depth, sibling);
+            print_children(children, 2, depth, sibling);
             break;
 
         case EXPR_CAST:
-            printf("%s\n", typeStr(expr->as.cast.to));
-            printExpr(expr->as.cast.operand, depth + 1, 1, sibling | (1 << depth));
+            printf("%s\n", datatype_str(expr->as.cast.to));
+            print_expr(expr->as.cast.operand, depth + 1, 1, sibling | (1 << depth));
             break;
 
         default:


### PR DESCRIPTION
## ⚠️ Note
`debug.h` includes `ast.h` which does not exist yet, causing main to be broken right now. 
I had planned to add a temporary `ast.h` to fix this, but after discussion with 
@PixelRifts we decided to hold off and wait for the proper implementation to land.

---

## Changes

### `include/rocky/debug/debug.h`
- Renamed `TokenFlags` enum to `TokenPrintFlags`
- Prefixed all enum members with `TOK_PRINT_FLAG_` to avoid global namespace pollution
- Updated `print_token` signature to use `TokenPrintFlags` instead of `unsigned int`
- Fixed sample usage in comments to reflect new function and flag names
- Renamed all functions to use snake_case instead of camel case

### `src/debug/debug.c`
- Updated all flag references to use new `TOK_PRINT_FLAG_` prefixed names
- Added Windows ANSI color support via `GetConsoleMode` from `windows.h`
- Kept `isatty` fallback for Linux/Mac via `unistd.h`
- Both are conditionally compiled using `#ifdef _WIN32`