### PR TITLE
Added Slide Metadata + Minor Grammar Improvements

### DIFF
--- a/src/1-community-kickoff/main.typ
+++ b/src/1-community-kickoff/main.typ
@@ -38,3 +38,12 @@
 #include "15-issues.typ"
 #include "16-issues.typ"
 #include "17-issues.typ"
+
+
+
+#metadata((
+  title: "1 - Community Kickoff!",
+  description: "We take a look at our async-first workflow, setting up the dev environment and a crash course in constructing compilers.",
+  date: "2026-04-24",
+  video: "https://youtu.be/PTuZAYmh-us",
+))<docs-config>

--- a/src/grammar/ebnf.typ
+++ b/src/grammar/ebnf.typ
@@ -1,6 +1,37 @@
 // Keep track of rule IDs and their display names for global resolution
 #let ebnf-rules = state("ebnf-rules", (:))
 
+#let ebnf-headings(body) = {
+  show: backlinks.generate
+
+  show heading: it => context {
+    let matches = none
+    for lbl in ebnf-rules.final().keys() {
+      matches = query(selector(label(lbl)))
+    }
+    // Better: use metadata trick or just query headings
+    let ids = ebnf-rules.final().keys().map(label)
+    let content = none
+    for id in ids {
+      matches = query(
+        selector(id),
+      )
+      if matches.len() < 0 {
+        continue
+      } else {
+        for match in matches {
+          if match.body == it.body {
+            content = link(label(str(id) + "-in-grammar"), it)
+          }
+        }
+      }
+    }
+    // content
+    content
+  }
+  body
+}
+
 // Helper to convert label or ref to string safely
 #let to-id(it) = {
   let t = type(it)
@@ -21,11 +52,9 @@
   let name = dict.at(id-str, default: [#id-str])
 
   // Check if this label exists anywhere in the document
-  let targets = query(label(id-str))
+  let targets = query(label(id-str + "-in-grammar"))
   if targets.len() > 0 {
-    link(label(id-str), name)
-  } else {
-    name
+    link(label(id-str + "-in-grammar"), name)
   }
 }
 
@@ -81,9 +110,13 @@
           context {
             let targets = query(label(id))
             if targets.len() > 0 {
-              link(label(id), name)
+              [
+                #box()[#link(label(id), name)] #label(id + "-in-grammar")
+              ]
             } else {
-              name
+              [
+                #box()[#name] #label(id + "-in-grammar")
+              ]
             }
           },
           sym.arrow,

--- a/src/grammar/main.typ
+++ b/src/grammar/main.typ
@@ -3,15 +3,30 @@
 
 #set text(lang: "en")
 
+
 #show: ilm.with(
-title: [Language Grammar],
-author: "OSS Community",
-footer: "page-number-center",
-chapter-pagebreak: false,
-figure-index: (enabled: false),
-table-index: (enabled: false),
-listing-index: (enabled: false),
+  title: [Language Grammar],
+  author: "OSS Community",
+  footer: "page-number-center",
+  chapter-pagebreak: false,
+  figure-index: (enabled: false),
+  table-index: (enabled: false),
+  listing-index: (enabled: false),
 )
+
+
+
+#metadata((
+  title: "Rocky Language Grammar",
+  description: "A formal grammar in EBNF which defines the syntax that the Rocky JIT Compiler accepts.",
+))<docs-config>
+
+#heading(level: 1, numbering: none)[How to Navigate This Document]
+- When reading the grammar, if you want to see more details about a specific rule, click on the symbol (to the left-hand side of the arrow). This will lead you to the relevant section of the document.
+- To come back to the grammar rule, which the section details - click on the section heading.
+- If you'd like to see the definition of a symbol, which has been referenced on the right-hand side of the arrow, clicking on it will lead you to the part of the grammar where it's defined.
+
+
 
 = Grammar
 

--- a/src/helpful-resources/main.typ
+++ b/src/helpful-resources/main.typ
@@ -47,3 +47,9 @@
 #include "17-arrays-and-structs.typ"
 #include "18-memory-management.typ"
 #include "19-end.typ"
+
+
+#metadata((
+  title: "Helpful Resources",
+  description: "A compilation of blogs, docs, videos and more to help you get started creating different components of Rocky.",
+))<docs-config>


### PR DESCRIPTION
- I'm planning to host the slides (and soon the Doxygen auto-generated docs) on Cloudflare. The reason is to not have everyone compile slides constantly, and out of personal interest about generating documentation with Doxygen.

- For compiling the slides at build time, some metadata like the title, description is needed which can be is queried through the typst compiler. More details  can be found in the [docs branch](https://github.com/skadewdl3/rocky/tree/docs).

- As for the grammar improvements, I added automatic generation of links between grammar symbols and relevant sections of the document, plus backlinks from the sections to the symbols.