### PR TITLE
Merge Windows ANSI Sequence Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(test_src ${TEST_SOURCES})
 
     get_filename_component(test_dir ${test_src} DIRECTORY)
     file(RELATIVE_PATH rel_path_from_tests ${CMAKE_SOURCE_DIR}/tests ${test_dir})
-    
+
     if(rel_path_from_tests STREQUAL "" OR rel_path_from_tests STREQUAL ".")
         set(test_name "tests_${test_file}")
         set(test_label "${test_file}")

--- a/include/rocky/debug.h
+++ b/include/rocky/debug.h
@@ -7,31 +7,32 @@
 
 /* Bitmask enum for conditional printing of tokens */
 typedef enum {
-    KIND = 1 << 0,
-    LEXEME = 1 << 1,
-    LINE = 1 << 2,
-    COL = 1 << 3,
-} TokenFlags;
+    TOK_PRINT_FLAG_KIND = 1 << 0,
+    TOK_PRINT_FLAG_LEXEME = 1 << 1,
+    TOK_PRINT_FLAG_LINE = 1 << 2,
+    TOK_PRINT_FLAG_COL = 1 << 3,
+    TOK_PRINT_ALL = 0xF,
+} TokenPrintFlags;
 
-/* Convert TokenType enum to a human-readable string. */
-const char* tokenTypeStr(TokenType type);
+/* Convert TokenKind enum to a human-readable string. */
+const char* token_type_str(TokenKind type);
 
 /* Convert UnaryOp enum to a human-readable string. */
-const char* unaryOpStr(UnaryOp op);
+const char* unary_op_str(UnaryOp op);
 
 /* Convert TypeKind enum to a human-readable string. */
-const char* typeStr(TypeKind t);
+const char* datatype_str(TypeKind t);
 
 /* Convert BinaryOP enum to a human-readable string. */
-const char* binaryOpStr(BinaryOp op);
+const char* binary_op_str(BinaryOp op);
 
 /* Diagnostic printer for lexer
  * Params:
  * 1.token: pointer to the token struct.
  * 2.flags: bitmask specifying which fields to print (KIND, LEXEME, LINE, COL).
- * Sample usage: printToken(token, KIND | LINE) will print the token type and its line number.
+ * * Sample usage: print_token(token, TOK_PRINT_FLAG_KIND | TOK_PRINT_FLAG_LINE) will print the token type and its line.
  * */
-void printToken(Token* token, unsigned int flags);
+void print_token(Token* token, TokenPrintFlags flags);
 
 /* Diagnostic printer for AST nodes
  * Params:
@@ -41,6 +42,5 @@ void printToken(Token* token, unsigned int flags);
  * 4. sibling: bitmask tracking which ancestor levels were the last child, used for drawing tree branches correctly.
  * Sample Usage: printExpr(expr, 0, 1, 0);
  * */
-void printExpr(const Expr* expr, int depth, int isLast, int sibling);
-void printAll(void);
+void print_expr(const Expr* expr, int depth, int isLast, int sibling);
 #endif

--- a/include/rocky/lexer/token.h
+++ b/include/rocky/lexer/token.h
@@ -52,11 +52,11 @@ typedef enum {
     TOKEN_SEMICOLON,
     TOKEN_EOF,
     TOKEN_INVALID,
-} TokenType;
+} TokenKind;
 
 /* Lexeme is represented as a slice (start pointer+length) into original source buffer */
 typedef struct {
-    TokenType type;     // type of token
+    TokenKind type;     // type of token
 
     const char *start;  // pointer to first character of lexeme
     size_t length;      // length of lexeme
@@ -66,4 +66,4 @@ typedef struct {
 
 } Token;
 
-#endif 
+#endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,13 +1,28 @@
-#include <rocky/debug.h>
-#include<stdio.h>
+#include <stdio.h>
 #include <inttypes.h>
-#include <unistd.h>
 
-static int use_color(void) {
-    return isatty(fileno(stdout));
-}
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    static int use_color(void) {
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hOut == INVALID_HANDLE_VALUE) return 0;
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(hOut, &dwMode)) return 0;
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        return SetConsoleMode(hOut, dwMode);
+    }
+#else
+    #include <unistd.h>
+    static int use_color(void) {
+        return isatty(fileno(stdout));
+    }
+#endif
 
-const char* tokenTypeStr(TokenType type) {
+
+#include <rocky/debug.h>
+
+const char* token_type_str(TokenKind type) {
     switch (type) {
         /*  Literals  */
         case TOKEN_INT: return "INT";
@@ -35,7 +50,7 @@ const char* tokenTypeStr(TokenType type) {
     }
 }
 
-void printToken(Token* token, unsigned int flags) {
+void print_token(Token* token, TokenPrintFlags flags) {
     //Null guard
     if (!token) {
         printf("[NULL TOKEN]\n");
@@ -50,11 +65,11 @@ void printToken(Token* token, unsigned int flags) {
     const char *red    = color ? "\e[35m" : "";
     const char *reset  = color ? "\e[0m"  : "";
 
-    if (flags & KIND)
+    if (flags & TOK_PRINT_FLAG_KIND)
         printf("%s%-15s%s   ",
-               cyan, tokenTypeStr(token->type), reset);
+               cyan, token_type_str(token->type), reset);
 
-    if (flags & LEXEME) {
+    if (flags & TOK_PRINT_FLAG_LEXEME) {
         if (token->start) {
             printf("%s%-15.*s%s   ",
                    green, (int)token->length, token->start, reset);
@@ -64,18 +79,18 @@ void printToken(Token* token, unsigned int flags) {
         }
     }
 
-    if (flags & LINE)
+    if (flags & TOK_PRINT_FLAG_LINE)
         printf("%s%-5d%s   ",
                yellow, token->line, reset);
 
-    if (flags & COL)
+    if (flags & TOK_PRINT_FLAG_COL)
         printf("%s%-5d%s   ",
                red, token->column, reset);
 
     printf("\n");
 }
 
-const char* unaryOpStr(UnaryOp op) {
+const char* unary_op_str(UnaryOp op) {
     switch (op) {
         case UNOP_NEG: return "-";
         case UNOP_BITNOT: return "~";
@@ -84,7 +99,7 @@ const char* unaryOpStr(UnaryOp op) {
     }
 }
 
-const char* typeStr(TypeKind t) {
+const char* datatype_str(TypeKind t) {
     switch (t) {
         case TYPE_INT: return "int";
         case TYPE_FLOAT: return "float";
@@ -94,7 +109,7 @@ const char* typeStr(TypeKind t) {
     }
 }
 
-const char* binaryOpStr(BinaryOp op) {
+const char* binary_op_str(BinaryOp op) {
     switch (op) {
 
         /* arithmetic */
@@ -143,11 +158,11 @@ const char* binaryOpStr(BinaryOp op) {
  *  - depth: current depth in the AST
  *  - sibling: bitmask tracking which ancestor levels were last children
  */
-void printChildren(const Expr** children, int count, int depth, int sibling) {
+void print_children(const Expr** children, int count, int depth, int sibling) {
     for (int i = 0; i < count; i++) {
         int isLast = (i == count - 1);
         int newMask = sibling | (isLast << depth);
-        printExpr(children[i], depth + 1, isLast, newMask);
+        print_expr(children[i], depth + 1, isLast, newMask);
     }
 }
 
@@ -160,7 +175,7 @@ void printChildren(const Expr** children, int count, int depth, int sibling) {
  * If a bit is set, we print spaces instead of vertical lines (│),
  * ensuring correct tree visualization across multiple branches.
  */
-void printExpr(const Expr* expr, int depth, int isLast, int sibling) {
+void print_expr(const Expr* expr, int depth, int isLast, int sibling) {
     //Null guard
     if (!expr) {
         printf("[NULL EXPR]\n");
@@ -189,7 +204,7 @@ void printExpr(const Expr* expr, int depth, int isLast, int sibling) {
 
     switch(expr->kind) {
         case EXPR_INT_LIT:
-            printf("%ld\n", expr->as.ival);
+            printf("%lld\n", expr->as.ival);
             break;
 
         case EXPR_FLOAT_LIT:
@@ -205,18 +220,18 @@ void printExpr(const Expr* expr, int depth, int isLast, int sibling) {
             break;
 
         case EXPR_UNARY:
-            printf("%s\n", unaryOpStr(expr->as.unary.op));
-            printExpr(expr->as.unary.operand, depth + 1, 1, sibling | (1 << depth));
+            printf("%s\n", unary_op_str(expr->as.unary.op));
+            print_expr(expr->as.unary.operand, depth + 1, 1, sibling | (1 << depth));
             break;
         case EXPR_BINARY:
-            printf("%s\n", binaryOpStr(expr->as.binary.op));
+            printf("%s\n", binary_op_str(expr->as.binary.op));
             const Expr* children[] = {expr->as.binary.lhs, expr->as.binary.rhs};
-            printChildren(children, 2, depth, sibling);
+            print_children(children, 2, depth, sibling);
             break;
 
         case EXPR_CAST:
-            printf("%s\n", typeStr(expr->as.cast.to));
-            printExpr(expr->as.cast.operand, depth + 1, 1, sibling | (1 << depth));
+            printf("%s\n", datatype_str(expr->as.cast.to));
+            print_expr(expr->as.cast.operand, depth + 1, 1, sibling | (1 << depth));
             break;
 
         default:

--- a/src/parser.c
+++ b/src/parser.c
@@ -26,7 +26,7 @@ static Token advance(Parser *p) {
     return t;
 }
 
-static Token expect(Parser *p, TokenType kind) {
+static Token expect(Parser *p, TokenKind kind) {
     Token t = advance(p);
     if (t.type != kind) {
         fprintf(stderr, "parse error at line %d col %d: "
@@ -41,7 +41,7 @@ static Token expect(Parser *p, TokenType kind) {
 
 typedef struct { int lbp; int rbp; } BP;
 
-static BP infix_bp(TokenType k) {
+static BP infix_bp(TokenKind k) {
     switch (k) {
         case TOKEN_PIPEPIPE:  return (BP){ 4,  5  };
         case TOKEN_AMPAMP:    return (BP){ 6,  7  };
@@ -65,7 +65,7 @@ static BP infix_bp(TokenType k) {
     }
 }
 
-static int prefix_bp(TokenType k) {
+static int prefix_bp(TokenKind k) {
     switch (k) {
         case TOKEN_MINUS:
         case TOKEN_TILDE:
@@ -76,7 +76,7 @@ static int prefix_bp(TokenType k) {
 
 /* ── Operator mapping ────────────────────────────────────── */
 
-static UnaryOp tok_to_unop(TokenType k) {
+static UnaryOp tok_to_unop(TokenKind k) {
     switch (k) {
         case TOKEN_MINUS: return UNOP_NEG;
         case TOKEN_TILDE: return UNOP_BITNOT;
@@ -85,7 +85,7 @@ static UnaryOp tok_to_unop(TokenType k) {
     }
 }
 
-static BinaryOp tok_to_binop(TokenType k) {
+static BinaryOp tok_to_binop(TokenKind k) {
     switch (k) {
         case TOKEN_PLUS:      return BINOP_ADD;
         case TOKEN_MINUS:     return BINOP_SUB;

--- a/tests/lexer.c
+++ b/tests/lexer.c
@@ -8,7 +8,7 @@ void tearDown(void) {}
 
 Lexer lexer;
 
-static void assert_token(const char *source, TokenType expected_type, const char *expected_lexeme) {
+static void assert_token(const char *source, TokenKind expected_type, const char *expected_lexeme) {
     lexer_init(&lexer, source);
     Token token = lexer_next_token(&lexer);
     TEST_ASSERT_EQUAL_INT_MESSAGE(expected_type, token.type, source);

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -38,7 +38,7 @@ static Token tok_float(double v) {
     return t;
 }
 
-static Token tok_op(TokenType type) {
+static Token tok_op(TokenKind type) {
     Token t = {0};
     t.type   = type;
     t.line   = 1; t.column = 1;
@@ -110,7 +110,7 @@ void test_parser_unary(void) {
 }
 
 void test_parser_binary_arithmetic(void) {
-    TokenType ops[] = { TOKEN_PLUS, TOKEN_MINUS, TOKEN_STAR, TOKEN_SLASH, TOKEN_PERCENT };
+    TokenKind ops[] = { TOKEN_PLUS, TOKEN_MINUS, TOKEN_STAR, TOKEN_SLASH, TOKEN_PERCENT };
     BinaryOp bops[] = { BINOP_ADD, BINOP_SUB, BINOP_MUL, BINOP_DIV, BINOP_MOD };
 
     for (int i = 0; i < 5; i++) {
@@ -122,7 +122,7 @@ void test_parser_binary_arithmetic(void) {
 }
 
 void test_parser_binary_comparison(void) {
-    TokenType ops[] = { TOKEN_EQEQ, TOKEN_BANGEQ, TOKEN_LT, TOKEN_GT, TOKEN_LTEQ, TOKEN_GTEQ };
+    TokenKind ops[] = { TOKEN_EQEQ, TOKEN_BANGEQ, TOKEN_LT, TOKEN_GT, TOKEN_LTEQ, TOKEN_GTEQ };
     BinaryOp bops[] = { BINOP_EQ, BINOP_NEQ, BINOP_LT, BINOP_GT, BINOP_LE, BINOP_GE };
 
     for (int i = 0; i < 6; i++) {
@@ -134,7 +134,7 @@ void test_parser_binary_comparison(void) {
 }
 
 void test_parser_binary_bitwise(void) {
-    TokenType ops[] = { TOKEN_AMP, TOKEN_PIPE, TOKEN_CARET, TOKEN_LSHIFT, TOKEN_RSHIFT };
+    TokenKind ops[] = { TOKEN_AMP, TOKEN_PIPE, TOKEN_CARET, TOKEN_LSHIFT, TOKEN_RSHIFT };
     BinaryOp bops[] = { BINOP_BAND, BINOP_BOR, BINOP_BXOR, BINOP_SHL, BINOP_SHR };
 
     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
Supersedes #22.

- Fixed merge conflicts.
- Renamed `TokenType` to `TokenKind` everywhere to prevent redefinition issues with `windows.h`